### PR TITLE
fix: add proper spaces to make the hashtag work

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -186,7 +186,7 @@ translations:
     t: 分享至 Twitter
   - key: thanks.share_score_message
     t: >
-      我正在参与#{hashtag}调查问卷，我的分数排名是 {score}% 。点击链接和我一起参与调查问卷： {shareUrl}
+      我正在参与 #{hashtag} 调查问卷，我的分数排名是 {score}%。点击链接和我一起参与调查问卷： {shareUrl}
   # share
   - key: general.share_subject
     t: >


### PR DESCRIPTION
![Screenshot_2024-08-31-01-14-31-754_com twitter android-edit](https://github.com/user-attachments/assets/83ed3121-6899-4ea4-a8fe-b1082fe6c573)

Current tweet text lacks spaces around the hashtag.