### PR TITLE
feat: add ai2026.yml Chinese translation for State of AI 2026

### DIFF
--- a/ai2026.yml
+++ b/ai2026.yml
@@ -1,0 +1,426 @@
+locale: zh-Hans
+translations:
+  - key: general.ai2026.css2026_banner
+    t: >
+      参与 State of CSS 2026 调查，看看今年 CSS 有哪些新变化 →
+
+  - key: general.ai2026.survey_intro
+    t: |
+
+      我们已经"距离被 AI 取代还有六个月"好几年了，这意味着两种情况之一：要么那些末日预言被夸大了，永远不会成真；*要么*它们一直都是对的，程序员比以往任何时候都更接近于加入点灯工和电梯操作员的行列，被扫进历史的垃圾堆。
+
+      又或者真相介于两者之间——我们的工作会改变，但不会完全消失；有些人适应新的常态，有些人则告别编程，最终实现成为木匠的终身梦想。
+
+      与此同时，我们所能做的就是尽力弄清楚当前的情况，而这要从参与第二版 Web 开发 AI 现状调查开始！
+
+  - key: overview.intro.ai2026
+    t: |
+
+      无论你是 AI 支持者还是反对者，我想大多数人都同意 AI 对我们作为开发者乃至整个世界都产生了巨大影响。
+
+      2026 年版 Web 开发 AI 现状调查收集了 **7,258** 名开发者的数据，提供了大量研究这一影响的有趣素材。虽然我建议你自行浏览完整的调查结果，但这里先列出四个关键趋势，帮助你开始探索数据。
+
+  - key: overview.ai_adoption.ai2026
+    t: |
+      ## #1：AI 采用率持续增长
+
+      必须承认，像这样的开放性调查可能存在固有的选择偏差。换句话说，一项以 AI 为主题的调查更有可能由已经使用并关心 AI 的开发者填写。
+
+      考虑到这一因素，如果我们假设这里揭示的趋势适用于整个行业，那么 AI 辅助编码从早期采用者的实验转变为标准实践的过程已经全面展开。
+
+      这一点从[受访者生成的 AI 代码比例](/en-US/usage/#ai_generated_code_balance)可以明显看出——该比例从 2025 年的平均 **28%** 跃升至今年的 **56%**，其中 75% 以上的区间增长最为显著（与上年相比的差异由条纹柱状覆盖层显示）。
+
+  - key: overview.ai_adoption2.ai2026
+    t: |
+      同样，受访者也更频繁地使用 AI，[声称"不断"使用 AI](/en-US/usage/#ai_code_generation_frequency) 的受访者比例同比翻了一番。
+
+  - key: overview.coding_agents.ai2026
+    t: |
+      ## #2：Claude Code 与编码代理的崛起
+
+      这种采用率增长在很大程度上是由新一代编码代理和助手推动的，**Claude Code** 在[编码代理的正面情绪评价](/en-US/coding-agents-assistants/#coding_agents_assistants_experience)中处于领先地位。
+
+  - key: overview.coding_agents2.ai2026
+    t: |
+
+      这些代理正在成为一种与 LLM 交互的更便捷方式，并可能取代聊天机器人、应用生成器和其他专用工具。
+
+      因此，尽管 **ChatGPT** 在纯粹的人气方面占有优势，但 **Claude** 才是[开发者实际付费最多的模型](/en-US/models/#models_paid_for)。
+
+  - key: overview.monetization.ai2026
+    t: |
+      ## #3：变现竞赛
+
+      说到多花钱的事：既然我们都已经沉迷于由史无前例的风险投资补贴的廉价 AI，这种集体成瘾使得 AI 实验室更容易开始提价。而这转化为[个人 AI 支出的明显增加](/en-US/usage/#ai_personal_expenses)，与去年相比。
+
+  - key: overview.monetization_2.ai2026
+    t: |
+      时间会告诉我们，这种增加的变现能否证明当前令人瞠目的 AI 公司估值是合理的，或者相反，意味着我们正处于[一个 AI 泡沫](/en-US/opinions/#ai_bubble_currently)中。但无论如何，调查受访者确信我们正处于泡沫之中。
+
+  - key: overview.risk_factors.ai2026
+    t: |
+      ## #4：风险因素增加
+
+      在谈论 AI 进展的同时不提及这些进步带来的许多问题，是不负责任的。
+
+      我们中的许多人确实面临着因 AI 进步而[失去生计](/en-US/opinions/#job_security_threat)的风险。毕竟，无论 AI 是否真的能胜任我们的工作，开发者被取代所需的只是管理层*相信*它可以。
+
+  - key: overview.risk_factors2.ai2026
+    t: |
+      但 [AI 风险](/en-US/risks-pain-points/#ai_risks)的清单远不止于此。
+
+      此时此刻，世界各地的武装力量正在研发自主无人机和瞄准系统，这可能导致责任与问责的削弱；而这当然是在 AI 资源消耗不断增长和气候变化加速的背景下发生的。
+
+  - key: overview.risk_factors3.ai2026
+    t: |
+      即使你忽略这些外部因素，随着我们越来越依赖 AI，我们很难摆脱这样一种感觉：也许我们新的网络伙伴并没有完全对我们坦诚——**幻觉和不准确** 被列为[最常见的 AI 痛点](/en-US/risks-pain-points/#ai_pain_points)。
+
+  - key: overview.ai_future.ai2026
+    t: |
+      ## 无论我们愿不愿意，AI 的未来已经来临
+
+      老实说：我不确定所有这些将把我们带向何方。但无论你认为我们应该拥抱 AI、与之抗争，还是介于两者之间，有一件事是肯定的：忽视 AI 变得越来越困难了。
+
+      所以，如果你和我一样在这个复杂问题上还没有下定决心，希望[这些调查结果](/en-US/models/)能成为帮助你做出更明智决策的又一个数据点——而不必先问 ChatGPT。
+
+      <span class="conclusion__byline">– Sacha Greif</span>
+
+  # FAQ
+
+  - key: faq.results_released_ai2026
+    t: 结果什么时候发布？
+  - key: faq.results_released_ai2026.description
+    t: 调查将于 2026 年 4 月 10 日至 5 月 10 日进行，调查结果将在不久后发布。
+
+  - key: faq.survey_design_ai2026
+    t: 这项调查是如何设计的？
+  - key: faq.survey_design_ai2026.description
+    t: >
+      本次调查是根据一个涉及 AI 公司、浏览器厂商和 Web 开发社区的[公开设计过程](https://github.com/Devographics/surveys/issues/285)的结果而设计的。
+
+  ###########################################################################
+  # 图表说明
+  ###########################################################################
+
+  - key: figure.figure_claude_use_increase.ai2026
+    t: |
+      Claude 使用量的同比增长百分比，是所有模型中增幅最大的。
+
+  - key: figure.figure_average_model_use.ai2026
+    t: |
+      受访者平均使用过的模型数量。
+
+  - key: figure.figure_claude_paying_users.ai2026
+    t: |
+      为 Claude Code 付费的受访者比例。
+
+  - key: figure.figure_ai_generated_code_balance.ai2026
+    t: |
+      表示其全部编码输出已由 AI 生成的受访者比例。
+
+  - key: figure.figure_ai_code_generation_frequency.ai2026
+    t: |
+      每天使用 AI 生成代码的受访者比例。
+
+  - key: figure.figure_ai_pain_points.ai2026
+    t: |
+      将提示理解能力列为痛点的受访者比例下降幅度。
+
+  - key: figure.figure_integral_workflow.ai2026
+    t: |
+      现在将 AI 视为工作流程中不可或缺部分的受访者比例。
+
+  - key: figure.figure_reach_agi.ai2026
+    t: |
+      认为我们将在不久的将来实现 AGI 的受访者比例。
+
+  ###########################################################################
+  # 内容与要点分析
+  ###########################################################################
+
+  # 用户信息
+
+  - key: sections.user_info.description.ai2026
+    t: |
+      **7,258** 名受访者参与了第二版 Web 开发 AI 现状调查，参与人数同比增长 **73%**。
+
+  # 模型
+
+  - key: sections.models.description.ai2026
+    t: |
+      整个生态系统建立的基础。
+
+  - key: models.models_experience.takeaway.ai2026
+    t: |
+      虽然 **ChatGPT** 仍然是最常用的模型家族，但今年 **Claude** 获得了最多的正面评价——这预示着一个将在整个调查结果中回响的主题。
+
+      在光谱的另一端，**Grok** 是最令人讨厌的模型，许多评论者仅因其与 Elon Musk 和右翼意识形态的联系而在道德层面就持反对态度。
+
+  - key: models.models_ratios.takeaway.ai2026
+    t: |
+      **ChatGPT** 仍然是最常用的模型，但 **Claude** 和 **Gemini** 都取得了巨大的同比增长。
+
+      满意度数据进一步印证了这一趋势：**Claude** 保持领先地位，虽然 **ChatGPT** 目前仍居第二，但得分正以令人担忧的速度下降；而 **Gemini** 是唯一一个自去年以来实际上*增长*了百分点的模型。
+
+  - key: models.models_others.takeaway.ai2026
+    t: |
+      此处列出的大多数其他模型甚至不在去年的调查中，值得注意的是前三名（**Kimi**、**GLM** 和 **MiniMax**）都是由中国公司开发的，这表明 AI 的未来可能并不 exclusively 属于硅谷。
+
+  - key: models.models_cardinalities.takeaway.ai2026
+    t: |
+      受访者平均使用过 **4** 种不同模型这一事实表明，AI 领域仍然非常不稳定，用户非常愿意尝试新竞争者，如果它们证明更优越的话。
+
+  - key: models.models_paid_for.takeaway.ai2026
+    t: |
+      拥有最高的正面情绪已经是 **Claude** 的一大胜利，但它在人们实际付费的模型榜单上也名列前茅，这意味着 Anthropic 肯定做对了一些事情。
+
+  # 编码代理与助手
+
+  - key: coding_agents_assistants.coding_agents_assistants_experience.takeaway.ai2026
+    t: |
+      Claude 再次在正面情绪方面显示出对竞争对手的明显优势，**Claude Code** 高居榜首，尽管 **GitHub Copilot** 在技术上有更大的用户基础。
+
+  - key: coding_agents_assistants.coding_agents_assistants_ratios.takeaway.ai2026
+    t: |
+      **Claude Code** 和 **OpenAI Codex** 在受访者满意度方面不相上下，但 Anthropic 的编码工具实际使用量远超其竞争对手。
+
+  - key: coding_agents_assistants.coding_agents_assistants_others.takeaway.ai2026
+    t: |
+      鉴于其流行度，**OpenCode** 本应成为主要调查选项之一。但它通过在竞争中建立舒适领先来弥补这一遗漏，**Cursor** 紧随其后位居第二。
+
+  - key: coding_agents_assistants.coding_agents_assistants_cardinalities.takeaway.ai2026
+    t: |
+      鉴于这是一个较年轻且更有限的空间，开发者尝试过的编码代理数量相对有限，这并不令人意外。
+
+  - key: coding_agents_assistants.coding_agents_assistants_paid_for.takeaway.ai2026
+    t: |
+      与模型部分的结论相呼应，在开发者愿意为之掏腰包的编码助手中，**Claude Code** 也排名第一。
+
+  # 其他工具
+
+  - key: sections.other_tools.description.ai2026
+    t: 其他 AI 工具
+
+  - key: other_tools.ai_programming_languages.takeaway.ai2026
+    t: |
+      验证了其他调查中的趋势，**TypeScript** 现在已经成为 Web 的事实标准编程语言——至少就 AI 而言是如此。
+
+  - key: other_tools.image_generation.takeaway.ai2026
+    t: |
+      **Nano Banana** 在图像生成方面颇受欢迎，但许多受访者根本不使用这些工具，很大程度上是出于道德原因。正如一位评论者简洁地指出："[AI 图像生成器]粗俗、不道德且消耗大量资源"。
+
+  - key: other_tools.video_generation.takeaway.ai2026
+    t: |
+      随着 OpenAI 最近关停 **Sora**，AI 视频生成似乎未能兑现其承诺，这一趋势在此得到证实。正如同一位评论者所言："甚至更恶劣。"
+
+  - key: other_tools.app_generation.takeaway.ai2026
+    t: |
+      市场上不乏承诺通过单一提示生成整个应用的工具，但实际编码助手的崛起正威胁着使整个领域过时——至少对于专业 Web 开发者而言是如此。
+
+  - key: other_tools.code_review.takeaway.ai2026
+    t: |
+      随着 AI 使生成数千行代码变得前所未有的容易，改进我们审查所有这些代码的方式可能不是个坏主意，而 **CodeRabbit** 正在引领这一努力。
+
+  - key: other_tools.text_editors.takeaway.ai2026
+    t: |
+      虽然 **Cursor** 仍在努力证明专用 AI 优化 IDE 的优势，但大多数受访者仍然选择 **VS Code** 作为他们的编辑器。
+
+  - key: other_tools.ai_browser_apis.takeaway.ai2026
+    t: |
+      浏览器原生支持 AI 功能是一个吸引人的想法，有望降低延迟并可能更加环保，减少新建数据中心的需求。
+
+  - key: other_tools.ai_tools_others.takeaway.ai2026
+    t: |
+      **OpenCode** 再次登顶，而被大肆炒作的 **OpenClaw** 仅位列第四。
+
+  # 使用情况
+
+  - key: sections.usage.description.ai2026
+    t: |
+      开发者如何使用 AI。
+
+  - key: usage.ai_uses.takeaway.ai2026
+    t: |
+      虽然 **代码生成** 仍然排在首位，但值得注意的是 **代码审查**（今年新增的选项）直接跃升至第三位。毕竟，那些在周末通过 vibe coding 生成的 3 万行代码，总得在某个时候有人复核一下……
+
+  - key: usage.ai_generated_code_balance.takeaway.ai2026
+    t: |
+      与去年的差异令人震惊。那时，普通受访者只是偶尔使用 AI 生成一小部分代码；而今天，同样的开发者更有可能依赖 AI 来完成大部分编码工作。
+
+      虽然 AI 使用率全面上升，但值得注意的是，使用率较高的区间与编程经验中位数年数较低相关。正如你所预期的，使用像 **Claude Code** 这样的编码代理与更高比例的 AI 生成代码相关。
+
+  - key: usage.ai_generated_code_refactoring.takeaway.ai2026
+    t: |
+      同样，无需重构即可直接使用 AI 生成的代码已不再是例外情况——许多受访者表示只需要重构约 25% 的 AI 输出。
+
+  - key: usage.ai_code_refactoring_reasons.takeaway.ai2026
+    t: |
+      当受访者*确实*需要重构 AI 生成的代码时，罪魁祸首往往是**糟糕的代码风格**和**幻觉**。有趣的是，**变量重命名**似乎已不再是一个主要因素，这表明 LLM 在遵循指令和学习现有代码库方面正在变得更好。
+
+  - key: usage.ai_code_generation_frequency.takeaway.ai2026
+    t: |
+      很明显，AI 已经嵌入到我们的工作中：大多数受访者每天多次使用 AI，并且越来越多的群体在持续使用。
+
+      而且，你使用 AI 越频繁，你的编程经验中位数年限就越有可能较低。
+
+  - key: usage.ai_other_tasks_frequency.takeaway.ai2026
+    t: |
+      虽然本次调查的主要焦点是编码，但其他 AI 用途与上一版相比也有所增加。毕竟，如果你信任 AI 处理工作中的主要部分，那么信任它处理其他所有事情似乎也是合乎逻辑的。
+
+  - key: usage.ai_generated_code_type.takeaway.ai2026
+    t: |
+      与上次调查相比，几乎所有类型的生成代码都有所增加，特别是测试成为使用 AI 的一个关键原因。
+
+  - key: usage.ai_personal_expenses.takeaway.ai2026
+    t: |
+      享受 AI 好处却无需自己掏腰包的受访者比例同比大幅萎缩；而 **$100-$500** 月支出的群体正在显著增长。这可能是由于编码代理的兴起造成的——与简单的聊天机器人相比，它们通常带来更高的财务成本。
+
+  - key: usage.ai_personal_expenses.note.ai2026
+    t: 虽然 2026 年调查还包括一个关于公司 AI 支出的问题，但其数据无法使用，因为它没有明确说明问题是指全公司总支出还是人均支出。
+
+  - key: usage.industry_sector.takeaway.ai2026
+    t: |
+      在任何*其他*图表上，都可以使用我们内置的 **查询生成器** 来根据任何特定行业领域过滤调查结果。
+
+  - key: usage.ai_running_locally.takeaway.ai2026
+    t: |
+      越来越多的受访者尝试过本地 AI 模型。虽然它们目前还不及云端同类产品强大，但作为传统前沿实验室模型的更廉价替代品，它们具有巨大的颠覆潜力。
+
+  # 风险与痛点
+
+  - key: risks_pain_points.ai_risks.takeaway.ai2026
+    t: |
+      AI 行业从不避讳讨论该技术可能带来的灾难，可惜就是没有真正地，你知道的，*放慢脚步*哪怕一分钟。
+
+      这些风险包括排在首位的**工作岗位流失**，但同样包括 AI 在近期冲突中所展现的**军事用途**潜力，当然还有在一个已受气候变化威胁的世界中 AI 令人担忧的**环境影响**。
+
+      同样有趣的是，总体而言，女性和非男性受访者更可能担忧 AI 对环境的影响（**58%** 对比 **37%**）。
+
+      许多评论者抱怨只能选择三个选项的限制。正如有人所说："当你把所有这些负面社会影响放在一起时，其数量之多令人震惊。"
+
+  - key: risks_pain_points.ai_pain_points.takeaway.ai2026
+    t: |
+      在实际使用 AI 的问题上，**幻觉** 位居榜首。
+
+      这一问题特别令人沮丧的地方不仅在于需要处理错误的输出，更在于这些错误输出被*自信地*呈现为正确的——而模型本身对自己可能出错的潜力毫无察觉。
+
+  - key: risks_pain_points.ai_missing_features.takeaway.ai2026
+    t: |
+      证实了前一个问题的结果，**真实性** 是最缺乏的特性。在这个我们越来越怀疑人类同胞区分事实与虚构能力的时代，如果我们的 AI 至少不会也来欺骗我们，那就太好了。
+
+  - key: risks_pain_points.ai_happiness.takeaway.ai2026
+    t: |
+      对 AI 的总体满意度与去年相比没有太大变化，这又是一个开发者可能仍处于"观望"模式的信号。
+
+  # 观点
+
+  - key: sections.opinions.description.ai2026
+    t: 提出更深层次的问题
+
+  - key: opinions.integral_workflow.takeaway.ai2026
+    t: |
+      我们早已过了 AI 工具只是工作流程中可有可无的附加功能的阶段——大多数受访者现在完全依赖 AI。
+
+  - key: opinions.more_productive.takeaway.ai2026
+    t: |
+      比去年更多的人认为 AI 工具显著提高了他们的生产力。
+
+  - key: opinions.ai_reliance_worse_developers.takeaway.ai2026
+    t: |
+      矛盾的是，受访者也清楚地意识到对 AI 的依赖会导致整体开发技能下降。但正如一些评论者指出的，AI 本身可能弥补这一损失："技能更低，是的。能力更强，可能也没错。"
+
+  - key: opinions.job_security_threat.takeaway.ai2026
+    t: |
+      正如受访者敏锐地指出的，AI 不需要真的能取代你才能对你的工作构成威胁——只需要你的老板认为它可以就够了：令人担忧的是"AI 公司可以说服雇主 AI 可以取代我的工作，即使它实际上不能"。
+
+  - key: opinions.existential_risk.takeaway.ai2026
+    t: |
+      深入阅读评论会发现，关于 AI 存在风险的问题呈现出微妙的图景，共识是主要问题不是 AI 本身，而是我们如何使用它。
+
+  - key: opinions.ai_bubble_currently.takeaway.ai2026
+    t: |
+      许多受访者认为我们目前处于 AI 泡沫中。但他们也认识到，即使泡沫最终破裂，AI 也将继续存在。
+
+  - key: opinions.ai_quality_improving.takeaway.ai2026
+    t: |
+      尽管人们经常抱怨某个模型被最近的更新*彻底搞砸了*，但受访者总体上似乎一致认为，AI 工具的质量正在稳步提升。
+
+  - key: opinions.reach_agi.takeaway.ai2026
+    t: |
+      取决于你问谁，我们要么离 AGI 还有 6 个月，要么永远无法实现它（正如一条评论所说："LLM 不是通往 AGI 的路径。从来都不是。"）
+
+      总体而言，尽管 AI 研究人员痴迷于实现那个难以捉摸的目标，但其他人的感觉是，如果这意味着少推平几片雨林，我们很乐意继续使用当前的"愚蠢"AI 一段时间。
+
+  ###########################################################################
+  # 结论
+  ###########################################################################
+
+  - key: conclusion.ai2026.the_primeagen.bio
+    t: Startup CEO
+
+  - key: conclusion.ai2026.the_primeagen
+    t: |
+      这是最好的时代，也是最坏的时代。
+
+      软件从未像今天这样平易近人。举个例子，如果你发现一个新的库，你可以 `git clone` 它，然后基于该仓库请求个性化教程。绝对神奇。如果我在学习编码的时候有这样的东西，我无法想象我今天会走到哪一步。
+
+      但并非所有闪光的东西都是金子，我们的软件职业生涯从未如此不确定。许多大公司裁员，[Dario](https://en.wikipedia.org/wiki/Dario_Amodei) 定期宣称软件已经完蛋，以及一种普遍的比以往做更多工作却比以往更不满意的感觉。
+
+      更令人困惑的是，软件质量感觉正处于历史最低点。我几乎无法使用任何一个主流网站而不遇到 bug，而头条新闻和社交媒体上所宣扬的无限高质量软件的承诺仍然感觉远未兑现。
+
+      这就是 2026 年如此有趣的原因。尘埃尚未落定。骰子尚未掷下。还没有定论。未来几年可能是整个软件工程领域最有影响力的时期之一，而我们都有机会参与其中。
+
+      就我个人而言，这场革命最迷人的部分在于个人自律的作用。我们中的一些人按"简单按钮"的速度太快了，我也对此有罪——因为它太诱人了。我从未有过如此既有用又致命的东西。
+
+      在更个人的层面上，我内心有一部分感到悲伤。我所热爱的职业正在改变——不管我愿不愿意——更重要的是，我必须随之改变。请不要把这误解为我在说"只要会写提示就行"：我并不是在宣告软件工程已死，远非如此。我只是觉得那种戴上耳机、放着 [Miss Monique](https://www.youtube.com/channel/UClIIy-aQBXRi1OHupBcrjJw)、连续 6 个小时不停编码的时光越来越少了，而且可能也不需要那么多了。
+
+      我无法预见未来，但我可以做出一个对软件行业始终成立的承诺：**胜任是快乐的。**
+
+  ###########################################################################
+  # 赞助商
+  ###########################################################################
+
+  - key: sponsors.google_chrome.description
+    t: 感谢 Google Chrome 团队对我们工作的支持。
+
+  - key: sponsors.tokyodev.description
+    t: 在日本找到你的梦想开发者工作。
+
+  - key: sponsors.neon.description
+    t: 使用 Postgres 释放前沿 AI 应用的潜力。
+
+  ###########################################################################
+  # FAQ/关于
+  ###########################################################################
+
+  - key: about.content.ai2026
+    t: |
+      2026 年 Web 开发 AI 现状调查于 2026 年 4 月 8 日至 5 月 8 日进行，共收集了 7,258 份回复。结果于 2026 年 5 月 1 日发布。该调查由 [Devographics](https://devographics.com/) 运营，并得到特邀领域专家和开源贡献者的协助。
+
+      ### 调查目标
+
+      本调查旨在识别使用 AI 进行 Web 开发方面的新兴趋势，以帮助开发者做出更好的技术选择。
+
+      ### 调查设计
+
+      调查是与社区协作设计的，设有公开反馈期，调查大纲在 [GitHub](https://github.com/Devographics/surveys/issues/285) 上进行了讨论。
+
+      所有调查问题均为可选项。
+
+      ### 调查受众
+
+      该调查在线公开访问，受访者未经任何筛选。受访者主要包括过往 Devographics 调查（如 [State of JS](https://stateofjs.com/)、[State of CSS](https://stateofcss.com/) 等）的参与者（通过专门的邮件列表通知）以及社交媒体渠道的流量。
+
+      虽然调查对所有开发者开放，无论他们是否使用 AI，但调查主题本身可能会导致受访者群体偏向于对 AI 感兴趣的开发者。
+
+      应将其视为**特定开发者群体的快照**，并不代表整个生态系统的全貌。
+
+      ### 项目资金
+
+      本项目的资金来自合作伙伴的赞助。
+
+      任何贡献或赞助都非常感谢。我们尤其希望与更多浏览器厂商密切合作，因为他们在 Web 生态系统中扮演着核心角色。
+
+      ### 技术概述
+
+      你可以在这里找到关于调查如何运行的更深入的技术概述（英文）：[How the Devographics Surveys Are Run](https://dev.to/sachagreif/how-the-devographics-surveys-are-run-2023-edition-1p6a)。


### PR DESCRIPTION
Add complete zh-Hans translation for the State of Web Dev AI 2026 survey results content (`ai2026.yml`).

This file was missing from the zh-Hans locale repository. The translation covers all 77 entries from the English source, including:
- Survey introduction and overviews
- Four key trends: AI Adoption, Coding Agents, Monetization, Risk Factors
- Figures and charts descriptions
- Models, coding agents/assistants, tools sections
- Usage patterns and pain points
- Opinions and conclusion (The Primeagen)
- Sponsors and about section

cc @SachaG

Closes the gap for zh-Hans users viewing 2026 survey results at https://2026.stateofai.dev/zh-Hans/